### PR TITLE
feat: implement Google Analytics 4 tracking

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -34,6 +34,18 @@
     <link rel="stylesheet" href="contact-styles.css">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NG5MN5K8HM"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-NG5MN5K8HM', {
+            page_title: 'お問い合わせ - 表彰状メーカー',
+            page_location: window.location.href
+        });
+    </script>
+    
     <!-- 構造化データ（JSON-LD） -->
     <script type="application/ld+json">
     {

--- a/index.html
+++ b/index.html
@@ -34,6 +34,18 @@
     <link rel="stylesheet" href="styles.css">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NG5MN5K8HM"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-NG5MN5K8HM', {
+            page_title: '表彰状メーカー - トップページ',
+            page_location: window.location.href
+        });
+    </script>
+    
     <!-- 構造化データ（JSON-LD） -->
     <script type="application/ld+json">
     {
@@ -138,8 +150,8 @@
                         プロフェッショナルな表彰状が完成します。
                     </p>
                     <div class="hero-buttons">
-                        <a href="#download" class="btn btn-primary">今すぐダウンロード</a>
-                        <a href="#features" class="btn btn-secondary">詳しく見る</a>
+                        <a href="#download" class="btn btn-primary" onclick="gtag('event', 'click', { event_category: 'engagement', event_label: 'hero_download_button' })">今すぐダウンロード</a>
+                        <a href="#features" class="btn btn-secondary" onclick="gtag('event', 'click', { event_category: 'engagement', event_label: 'hero_features_button' })">詳しく見る</a>
                     </div>
                 </div>
                 <div class="hero-image">
@@ -231,14 +243,14 @@
                     お使いのデバイスに応じてダウンロードしてください。
                 </p>
                 <div class="download-buttons">
-                    <a href="#" class="download-btn ios-btn">
+                    <a href="#" class="download-btn ios-btn" onclick="gtag('event', 'click', { event_category: 'download', event_label: 'app_store_button' })">
                         <div class="btn-icon">📱</div>
                         <div class="btn-text">
                             <span class="btn-small">Download on the</span>
                             <span class="btn-large">App Store</span>
                         </div>
                     </a>
-                    <a href="#" class="download-btn android-btn">
+                    <a href="#" class="download-btn android-btn" onclick="gtag('event', 'click', { event_category: 'download', event_label: 'google_play_button' })">
                         <div class="btn-icon">🤖</div>
                         <div class="btn-text">
                             <span class="btn-small">GET IT ON</span>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -34,6 +34,18 @@
     <link rel="stylesheet" href="privacy-styles.css">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NG5MN5K8HM"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-NG5MN5K8HM', {
+            page_title: 'プライバシーポリシー - 表彰状メーカー',
+            page_location: window.location.href
+        });
+    </script>
+    
     <!-- 構造化データ（JSON-LD） -->
     <script type="application/ld+json">
     {
@@ -154,6 +166,15 @@
                         <h4>Google Analytics for Firebase</h4>
                         <ul>
                             <li>アプリ使用状況の分析のため</li>
+                            <li>プライバシーポリシー：<a href="https://policies.google.com/privacy" target="_blank" rel="noopener">https://policies.google.com/privacy</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="third-party-service">
+                        <h4>Google Analytics 4</h4>
+                        <ul>
+                            <li>Webサイトの使用状況分析のため</li>
+                            <li>匿名化された情報のみ収集</li>
                             <li>プライバシーポリシー：<a href="https://policies.google.com/privacy" target="_blank" rel="noopener">https://policies.google.com/privacy</a></li>
                         </ul>
                     </div>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -37,6 +37,18 @@
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="terms-styles.css">
     
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NG5MN5K8HM"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-NG5MN5K8HM', {
+            page_title: '利用規約 - 表彰状メーカー',
+            page_location: window.location.href
+        });
+    </script>
+    
     <!-- 構造化データ（JSON-LD） -->
     <script type="application/ld+json">
     {


### PR DESCRIPTION
- Add GA4 tracking code to all 4 pages (index, contact, privacy-policy, terms-of-service)
- Set measurement ID: G-NG5MN5K8HM
- Configure appropriate page_title for each page
- Implement event tracking for key user actions:
  - Hero section button clicks
  - App Store/Google Play download button clicks
- Update privacy policy to include GA4 usage disclosure
- Enable detailed website analytics and user behavior tracking